### PR TITLE
Fix swapped alive/dead cell shape

### DIFF
--- a/Gameoflife/src/Cell.java
+++ b/Gameoflife/src/Cell.java
@@ -16,13 +16,13 @@ public class Cell {
 		this.alive = alive;
 	}
 	
-	public char getAliveShape() {
-		return shape[0];
-	}
-	
-	public char getDeadShape() {
-		return shape[1];
-	}
+    public char getAliveShape() {
+            return shape[1];
+    }
+
+    public char getDeadShape() {
+            return shape[0];
+    }
 	
 	public char getCurrentShape() {
 		return this.shape[this.alive];


### PR DESCRIPTION
## Summary
- fix `getAliveShape` and `getDeadShape` returning the wrong symbols

## Testing
- `javac *.java` *(fails: package javafx.application does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6862bfe978c88327a1ff1d56d9abd1f2