### PR TITLE
Fix JavaFX module path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@ plugins {
     id 'application'
 }
 
+java {
+    modularity.inferModulePath = true
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
## Summary
- enable module path inference so JavaFX modules resolve correctly

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686597878e0083279337298becc1bc05