### PR TITLE
Add simulation stability detection

### DIFF
--- a/src/test/java/com/example/gameoflife/PetridishTest.java
+++ b/src/test/java/com/example/gameoflife/PetridishTest.java
@@ -1,0 +1,35 @@
+package com.example.gameoflife;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class PetridishTest {
+    @Test
+    void testStableBlockStops() throws Exception {
+        Petridish p = new Petridish();
+        p.setCellState(10,10,true);
+        p.setCellState(10,11,true);
+        p.setCellState(11,10,true);
+        p.setCellState(11,11,true);
+        String before = p.getBoardHash();
+        AtomicInteger iter = new AtomicInteger();
+        p.iterateLife(() -> iter.incrementAndGet() < 10);
+        assertEquals(before, p.getBoardHash());
+        assertTrue(iter.get() <= 2);
+    }
+
+    @Test
+    void testBlinkerStops() throws Exception {
+        Petridish p = new Petridish();
+        p.setCellState(5,5,true);
+        p.setCellState(5,6,true);
+        p.setCellState(5,7,true);
+        String before = p.getBoardHash();
+        AtomicInteger iter = new AtomicInteger();
+        p.iterateLife(() -> iter.incrementAndGet() < 10);
+        assertEquals(before, p.getBoardHash());
+        assertEquals(2, iter.get());
+    }
+}


### PR DESCRIPTION
## Summary
- allow Petridish cells to be set manually
- expose current board hash for tests
- add early termination logic to `iterateLife` using a callback and
  detection of repeated board states
- add unit tests for a stable block and a blinker oscillator

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686597f197848327aab9a9814cc862d2